### PR TITLE
Fix discord net logger forwarder log level for exceptions

### DIFF
--- a/src/Christofel.Application/Logging/DiscordNetLog.cs
+++ b/src/Christofel.Application/Logging/DiscordNetLog.cs
@@ -24,7 +24,14 @@ namespace Christofel.Application.Logging
         {
             using (_logger.BeginScope(message.Source))
             {
-                _logger.Log(FromLogSeverity(message.Severity), message.Exception, message.Message);
+                LogLevel logLevel = FromLogSeverity(message.Severity);
+
+                if (message.Exception != null && logLevel < LogLevel.Error)
+                {
+                    logLevel = LogLevel.Error;
+                }
+                
+                _logger.Log(logLevel, message.Exception, message.Message);
             }
             
             return Task.CompletedTask;


### PR DESCRIPTION
Logs with exceptions with them should be treated as Errors, not Warnings. Discord.NET was treating them as Warnings.
Now logs with exceptions from Discord.NET are always treated as Errors or Critical