### PR TITLE
Revise how plugins are loaded for better scalability

### DIFF
--- a/src/Christofel.Application/Assemblies/AssemblyLoader.cs
+++ b/src/Christofel.Application/Assemblies/AssemblyLoader.cs
@@ -1,9 +1,11 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Christofel.Application.Assemblies
 {
     public class AssemblyLoader
     {
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static ContextedAssembly Load(string path)
         {
             ReferencesLoadContext context = new ReferencesLoadContext(path);

--- a/src/Christofel.Application/Assemblies/ContextedAssembly.cs
+++ b/src/Christofel.Application/Assemblies/ContextedAssembly.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Christofel.Application.Assemblies
@@ -41,13 +43,17 @@ namespace Christofel.Application.Assemblies
                 return _assembly;
             }
         }
-
-        public void Detach()
+        
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public WeakReference Detach()
         {
+            WeakReference weakReference = new WeakReference(Context);
             Context.Unload();
             
-            _assembly = null!;
-            _context = null!;
+            _assembly = null;
+            _context = null;
+
+            return weakReference;
         }
     }
 }

--- a/src/Christofel.Application/Commands/PluginCommands.cs
+++ b/src/Christofel.Application/Commands/PluginCommands.cs
@@ -77,6 +77,11 @@ namespace Christofel.Application.Commands
                         .WithDescription("Name of the module")
                         .WithType(ApplicationCommandOptionType.String)
                     )
+                )
+                .AddOption(new SlashCommandOptionBuilder()
+                    .WithName("check")
+                    .WithDescription("Checks memory for any detached modules still left")
+                    .WithType(ApplicationCommandOptionType.SubCommand)
                 ).AddOption(new SlashCommandOptionBuilder()
                     .WithName("list")
                     .WithDescription("Print list of attached plugins")
@@ -102,6 +107,9 @@ namespace Christofel.Application.Commands
                     break;
                 case "list":
                     await HandleList(command);
+                    break;
+                case "check":
+                    await Check(command);
                     break;
             }
         }
@@ -200,6 +208,12 @@ namespace Christofel.Application.Commands
             string pluginMessage = "List of attached plugins:\n  " + string.Join("\n  ", plugins);
             
             return command.RespondAsync(pluginMessage, ephemeral: true);
+        }
+
+        private Task Check(SocketSlashCommand command)
+        {
+            _plugins.CheckDetached();
+            return command.RespondAsync("Check log for result");
         }
     }
 }

--- a/src/Christofel.Application/Commands/PluginCommands.cs
+++ b/src/Christofel.Application/Commands/PluginCommands.cs
@@ -150,8 +150,8 @@ namespace Christofel.Application.Commands
                 }
                 catch (Exception e)
                 {
+                    _logger.LogError(0, e, "Error loading plugin");
                     await command.RespondAsync("There was an error. Check the log.", ephemeral: true);
-                    throw;
                 }
             }
         }

--- a/src/Christofel.Application/Plugins/AttachedPlugin.cs
+++ b/src/Christofel.Application/Plugins/AttachedPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Christofel.Application.Assemblies;
 using Christofel.BaseLib.Plugins;
 
@@ -5,13 +6,26 @@ namespace Christofel.Application.Plugins
 {
     public class AttachedPlugin : IHasPluginInfo
     {
+        private IPlugin? _plugin;
+        
         public AttachedPlugin(IPlugin plugin, ContextedAssembly assembly)
         {
-            Plugin = plugin;
+            _plugin = plugin;
             PluginAssembly = assembly;
         }
-        
-        public IPlugin Plugin { get; }
+
+        public IPlugin Plugin
+        {
+            get
+            {
+                if (_plugin == null)
+                {
+                    throw new InvalidOperationException("Plugin was already detached");
+                }
+
+                return _plugin;
+            }
+        }
         
         public ContextedAssembly PluginAssembly { get; }
 
@@ -22,6 +36,12 @@ namespace Christofel.Application.Plugins
         public override string ToString()
         {
             return $@"{Name} ({Version})";
+        }
+
+        public WeakReference Detach()
+        {
+            _plugin = null;
+            return PluginAssembly.Detach();
         }
     }
 }

--- a/src/Christofel.Application/Plugins/DetachedPlugin.cs
+++ b/src/Christofel.Application/Plugins/DetachedPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Christofel.BaseLib.Plugins;
 
 namespace Christofel.Application.Plugins
@@ -10,6 +11,8 @@ namespace Christofel.Application.Plugins
             Description = plugin.Description;
             Version = plugin.Version;
         }
+        
+        public WeakReference? AssemblyContextReference { get; internal set; }
 
         public string Name { get; }
         public string Description { get; }

--- a/src/Christofel.Application/Plugins/PluginService.cs
+++ b/src/Christofel.Application/Plugins/PluginService.cs
@@ -205,7 +205,7 @@ namespace Christofel.Application.Plugins
 
         private string GetModulePath(string name)
         {
-            return Path.Join(Path.GetFullPath(_options.Folder), name + ".dll");
+            return Path.Join(Path.GetFullPath(_options.Folder), name, name + ".dll");
         }
 
         public Task StopAsync()

--- a/src/Christofel.HelloWorld/Christofel.HelloWorld.csproj
+++ b/src/Christofel.HelloWorld/Christofel.HelloWorld.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <_CopyPlugin Include="$(ProjectDir)/$(OutDir)/**/*" />
+        <_CopyPlugin Include="$(ProjectDir)/$(OutDir)/*" />
     </ItemGroup>
     <Target Name="CopyPluginFiles" AfterTargets="Build">
         <Message Text="Copying to Christofel.Application plugins folder..." />
-        <Copy SourceFiles="$(ProjectDir)/$(OutDir)/$(ProjectName).dll" DestinationFolder="$(SolutionDir)/Christofel.Application/$(OutDir)/Plugins/" />
+        <Copy SourceFiles="@(_CopyPlugin)" DestinationFolder="$(SolutionDir)/Christofel.Application/$(OutDir)/Plugins/$(ProjectName)" />
+        <Copy SourceFiles="@(_CopyPlugin)" DestinationFolder="$(SolutionDir)/Christofel.Application/$(OutDir)/Plugins/$(ProjectName)" />
     </Target>
 
     <PropertyGroup>


### PR DESCRIPTION
Implement part of #24 - shared assemblies that need to be shared will be always used from the default context. This is needed behavior and custom behavior for sharing data between plugins could be implemented in the future