### PR TITLE
Handler Creators did not handle optional arguments correctly

### DIFF
--- a/src/Christofel.CommandsLib/Extensions/ICommandHandlerCreatorExtensions.cs
+++ b/src/Christofel.CommandsLib/Extensions/ICommandHandlerCreatorExtensions.cs
@@ -15,7 +15,7 @@ namespace Christofel.CommandsLib.Extensions
         /// <param name="deleg">Delegate to execute with the command</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T> creator,
+        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T, Delegate> creator,
             Delegate deleg)
         {
             return creator
@@ -30,7 +30,7 @@ namespace Christofel.CommandsLib.Extensions
         /// <param name="matchers"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T> creator, params (Func<T, bool>, Delegate)[] matchers)
+        public static SlashCommandHandler CreateHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator, params (Func<T, bool>, U)[] matchers)
         {
             return creator.CreateHandlerForCommand(matchers.AsEnumerable());
         }
@@ -43,13 +43,13 @@ namespace Christofel.CommandsLib.Extensions
         /// <param name="matchers"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T> creator,
-            params (T, Delegate)[] matchers)
+        public static SlashCommandHandler CreateHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator,
+            params (T, U)[] matchers)
         where T : notnull
         {
             return creator
                 .CreateHandlerForCommand(matchers.Select(
-                    x => ValueTuple.Create<Func<T, bool>, Delegate>(((y) => x.Item1.Equals(y)), x.Item2)));
+                    x => ValueTuple.Create<Func<T, bool>, U>(((y) => x.Item1.Equals(y)), x.Item2)));
         }
     }
 }

--- a/src/Christofel.CommandsLib/HandlerCreator/CommandHandlerCreatorUtils.cs
+++ b/src/Christofel.CommandsLib/HandlerCreator/CommandHandlerCreatorUtils.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Christofel.CommandsLib.CommandsInfo;
 using Christofel.CommandsLib.Reflection;
@@ -19,25 +21,76 @@ namespace Christofel.CommandsLib.HandlerCreator
         /// <param name="getArguments"></param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public static SlashCommandHandler CreateHandler(Delegate function, Func<SocketSlashCommandData, IEnumerable<object?>?> getArguments)
+        public static SlashCommandHandler CreateHandler(Delegate function,
+            Func<SocketSlashCommandData, IEnumerable<object?>?> getArguments)
         {
             EfficientInvoker invoker = EfficientInvoker.ForDelegate(function);
-            
+
             return (command, token) =>
             {
                 List<object?> args = new() {command};
                 args.AddRange(getArguments(command.Data) ?? Enumerable.Empty<object?>());
                 args.Add(token);
 
-                object? data = invoker.Invoke(function, args.ToArray());
-
-                if (data is null)
-                {
-                    throw new InvalidOperationException($@"Command handler of {command.Data.Name} returned null instead of Task");
-                }
-
-                return (Task)data;
+                return Invoke(command.Data.Name, invoker, function, args.ToArray());
             };
+        }
+
+        /// <summary>
+        /// Create SlashCommandHandler from given Delegate.
+        /// Uses <see cref="EfficientInvoker"/> for invoking the delegate faster.
+        /// </summary>
+        /// <param name="function"></param>
+        /// <param name="getArguments"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static Func<SocketSlashCommand, T, CancellationToken, Task> CreateHandler<T>(Delegate function,
+            Func<SocketSlashCommandData, T, IEnumerable<object?>?> getArguments)
+        {
+            EfficientInvoker invoker = EfficientInvoker.ForDelegate(function);
+
+            return (command, helper, token) =>
+            {
+                List<object?> args = new() {command};
+                args.AddRange(getArguments(command.Data, helper) ?? Enumerable.Empty<object?>());
+                args.Add(token);
+
+                return Invoke(command.Data.Name, invoker, function, args.ToArray());
+            };
+        }
+
+        public static IEnumerable<object?> GetParametersFromOptions(Delegate function,
+            IEnumerable<SocketSlashCommandDataOption>? options)
+        {
+            ParameterInfo[] parameters = function.Method.GetParameters();
+            object?[] arguments = new object?[parameters.Length - 2];
+
+            if (options == null)
+            {
+                return arguments;
+            }
+
+            IEnumerable<SocketSlashCommandDataOption> socketSlashCommandDataOptions =
+                options as SocketSlashCommandDataOption[] ?? options.ToArray();
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                string name = parameters[i + 1].Name?.ToLower() ?? "";
+                arguments[i] = socketSlashCommandDataOptions.FirstOrDefault(x => x.Name == name)?.Value;
+            }
+
+            return arguments;
+        }
+
+        private static Task Invoke(string name, EfficientInvoker invoker, Delegate function, object?[] args)
+        {
+            object? data = invoker.Invoke(function, args.ToArray());
+
+            if (data is null)
+            {
+                throw new InvalidOperationException($@"Command handler of {name} returned null instead of Task");
+            }
+
+            return (Task) data;
         }
     }
 }

--- a/src/Christofel.CommandsLib/HandlerCreator/ICommandHandlerCreator.cs
+++ b/src/Christofel.CommandsLib/HandlerCreator/ICommandHandlerCreator.cs
@@ -19,13 +19,13 @@ namespace Christofel.CommandsLib.HandlerCreator
     /// Creator of SlashCommandHandler different types may be used for subcommands or custom matching
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface ICommandHandlerCreator<T>
+    public interface ICommandHandlerCreator<T, U>
     {
         /// <summary>
         /// Creates SlashCommandHandler for given matches
         /// </summary>
         /// <param name="matchers">List of matchers that specify what function is matched given conditions</param>
         /// <returns></returns>
-        public SlashCommandHandler CreateHandlerForCommand(IEnumerable<(Func<T, bool>, Delegate)> matchers);
+        public SlashCommandHandler CreateHandlerForCommand(IEnumerable<(Func<T, bool>, U)> matchers);
     }
 }

--- a/src/Christofel.CommandsLib/HandlerCreator/PlainCommandHandlerCreator.cs
+++ b/src/Christofel.CommandsLib/HandlerCreator/PlainCommandHandlerCreator.cs
@@ -11,18 +11,20 @@ namespace Christofel.CommandsLib.HandlerCreator
     /// Creates SlashCommandHandler for command without subcommands.
     /// It should receive only 1 matcher and that should always match
     /// </summary>
-    public class PlainCommandHandlerCreator : ICommandHandlerCreator<string>
+    public class PlainCommandHandlerCreator : ICommandHandlerCreator<string, Delegate>
     {
         public SlashCommandHandler CreateHandlerForCommand(IEnumerable<(Func<string, bool>, Delegate)> matchers)
         {
             var valueTuples = matchers as (Func<string, bool>, Delegate)[] ?? matchers.ToArray();
             if (valueTuples.Count() != 1)
             {
-                throw new InvalidOperationException("PlainCommandHandlerCreator can handle only one matcher that is always true");
+                throw new InvalidOperationException(
+                    "PlainCommandHandlerCreator can handle only one matcher that is always true");
             }
-            
+
             var matcher = valueTuples.FirstOrDefault();
-            return GetHandler(CommandHandlerCreatorUtils.CreateHandler(matcher.Item2, (data => data.Options.Select(x => x.Value))));
+            return GetHandler(CommandHandlerCreatorUtils.CreateHandler(matcher.Item2,
+                (data => CommandHandlerCreatorUtils.GetParametersFromOptions(matcher.Item2, data.Options))));
         }
 
         private SlashCommandHandler GetHandler(SlashCommandHandler handler)

--- a/src/Christofel.CommandsLib/HandlerCreator/SubCommandHandlerCreator.cs
+++ b/src/Christofel.CommandsLib/HandlerCreator/SubCommandHandlerCreator.cs
@@ -23,8 +23,9 @@ namespace Christofel.CommandsLib.HandlerCreator
             List<HandlerMatcher> realMatchers = matchers
                 .Select(x => new HandlerMatcher(
                     x.Item1,
-                    CommandHandlerCreatorUtils.CreateHandler(x.Item2, data => data.Options.First().Options?.Select(y => y.Value))
-                    ))
+                    CommandHandlerCreatorUtils.CreateHandler(x.Item2,
+                        data => CommandHandlerCreatorUtils.GetParametersFromOptions(x.Item2, data.Options.First().Options))
+                ))
                 .ToList();
 
             return GetHandler(realMatchers);


### PR DESCRIPTION
Commands were sent without optional arguments if they weren't present.
That caused a bug where options were wrongly matched to delegate arguments.
Fixed this matching to parameter names instead of positions