### PR TITLE
Don't log known programmes again

### DIFF
--- a/src/Core/Christofel.Common/Database/Models/ProgrammeRoleAssignment.cs
+++ b/src/Core/Christofel.Common/Database/Models/ProgrammeRoleAssignment.cs
@@ -30,11 +30,11 @@ namespace Christofel.Common.Database.Models
         /// <summary>
         /// Gets or sets id of the assignment.
         /// </summary>
-        public int AssignmentId { get; set; }
+        public int? AssignmentId { get; set; }
 
         /// <summary>
         /// Gets or sets the assignment.
         /// </summary>
-        public RoleAssignment Assignment { get; set; } = null!;
+        public RoleAssignment? Assignment { get; set; } = null!;
     }
 }

--- a/src/Core/Christofel.Common/Migrations/20231103224922_ProgrammeRole_MakeRoleAssignmentOptional.Designer.cs
+++ b/src/Core/Christofel.Common/Migrations/20231103224922_ProgrammeRole_MakeRoleAssignmentOptional.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Christofel.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Christofel.Common.Migrations
 {
     [DbContext(typeof(ChristofelBaseContext))]
-    partial class ChristofelBaseContextModelSnapshot : ModelSnapshot
+    [Migration("20231103224922_ProgrammeRole_MakeRoleAssignmentOptional")]
+    partial class ProgrammeRole_MakeRoleAssignmentOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Core/Christofel.Common/Migrations/20231103224922_ProgrammeRole_MakeRoleAssignmentOptional.cs
+++ b/src/Core/Christofel.Common/Migrations/20231103224922_ProgrammeRole_MakeRoleAssignmentOptional.cs
@@ -1,0 +1,44 @@
+﻿//
+//  20231103224922_ProgrammeRole_MakeRoleAssignmentOptional.cs
+//
+//  Copyright (c) Christofel authors. All rights reserved.
+//  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Christofel.Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProgrammeRole_MakeRoleAssignmentOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "AssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "AssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Libs/Christofel.CtuAuth/Auth/Steps/ProgrammeRoleStep.cs
+++ b/src/Libs/Christofel.CtuAuth/Auth/Steps/ProgrammeRoleStep.cs
@@ -59,19 +59,22 @@ namespace Christofel.CtuAuth.Auth.Steps
                 return Result.FromSuccess();
             }
 
-            var roles = await data.DbContext.ProgrammeRoleAssignments
+            var assignments = await data.DbContext.ProgrammeRoleAssignments
                 .AsNoTracking()
                 .Where(x => x.Programme == programmeTitle)
                 .Include(x => x.Assignment)
-                .Select(x => new CtuAuthRole { RoleId = x.Assignment.RoleId, Type = x.Assignment.RoleType })
+                .Select(x => x.Assignment)
                 .ToListAsync(ct);
 
-            if (roles.Count == 0)
+            if (assignments.Count == 0)
             {
                 _logger.LogWarning
                     ($"Could not find mapping for programme {programmeTitle} for user {data.GuildUser}");
             }
 
+            var roles = assignments
+                .Where(x => x is not null)
+                .Select(x => new CtuAuthRole { RoleId = x!.RoleId, Type = x.RoleType });
             data.Roles.AddRange(roles);
 
             return Result.FromSuccess();


### PR DESCRIPTION
Makes programme role assignment in database optional. In case it's not filled, no role is assigned, but there is no message logged. Prevents known programme, such as "Informatika" (common for all FIT students)

Solves #151.