### PR TITLE
Assigning programme roles in complicated scenarios

### DIFF
--- a/src/Core/Christofel.Common/Database/ChristofelBaseContext.cs
+++ b/src/Core/Christofel.Common/Database/ChristofelBaseContext.cs
@@ -96,6 +96,12 @@ namespace Christofel.Common.Database
                 .HasForeignKey(x => x.AssignmentId)
                 .OnDelete(DeleteBehavior.Restrict);
 
+            modelBuilder.Entity<ProgrammeRoleAssignment>()
+                .HasOne(x => x.GraduationAssignment)
+                .WithMany(x => x.GraduationProgrammeRoleAssignments)
+                .HasForeignKey(x => x.GraduationAssignmentId)
+                .OnDelete(DeleteBehavior.Restrict);
+
             modelBuilder.Entity<TitleRoleAssignment>()
                 .HasOne(x => x.Assignment)
                 .WithMany(x => x.TitleRoleAssignments)

--- a/src/Core/Christofel.Common/Database/Models/ProgrammeRoleAssignment.cs
+++ b/src/Core/Christofel.Common/Database/Models/ProgrammeRoleAssignment.cs
@@ -36,5 +36,23 @@ namespace Christofel.Common.Database.Models
         /// Gets or sets the assignment.
         /// </summary>
         public RoleAssignment? Assignment { get; set; } = null!;
+
+        /// <summary>
+        /// Gets or sets id of the graduation assignment.
+        /// </summary>
+        /// <remarks>
+        /// This role is assigned to people that have graduated this programme,
+        /// and aren't on this programme anymore.
+        /// </remarks>
+        public int? GraduationAssignmentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the graduation assignment.
+        /// </summary>
+        /// <remarks>
+        /// This role is assigned to people that have graduated this programme,
+        /// and aren't on this programme anymore.
+        /// </remarks>
+        public RoleAssignment? GraduationAssignment { get; set; } = null!;
     }
 }

--- a/src/Core/Christofel.Common/Database/Models/RoleAssignment.cs
+++ b/src/Core/Christofel.Common/Database/Models/RoleAssignment.cs
@@ -50,6 +50,11 @@ namespace Christofel.Common.Database.Models
         public virtual ICollection<ProgrammeRoleAssignment>? ProgrammeRoleAssignments { get; set; }
 
         /// <summary>
+        /// Gets or sets programme role assignments that reference this assignment as graduation assignmenton.
+        /// </summary>
+        public virtual ICollection<ProgrammeRoleAssignment>? GraduationProgrammeRoleAssignments { get; set; }
+
+        /// <summary>
         /// Gets or sets title role assignments that reference this assignment.
         /// </summary>
         public virtual ICollection<TitleRoleAssignment>? TitleRoleAssignments { get; set; }

--- a/src/Core/Christofel.Common/Migrations/20250613142500_AddGraduationProgrammeRole.Designer.cs
+++ b/src/Core/Christofel.Common/Migrations/20250613142500_AddGraduationProgrammeRole.Designer.cs
@@ -4,6 +4,7 @@ using Christofel.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Christofel.Common.Migrations
 {
     [DbContext(typeof(ChristofelBaseContext))]
-    partial class ChristofelBaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250613142500_AddGraduationProgrammeRole")]
+    partial class AddGraduationProgrammeRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Core/Christofel.Common/Migrations/20250613142500_AddGraduationProgrammeRole.cs
+++ b/src/Core/Christofel.Common/Migrations/20250613142500_AddGraduationProgrammeRole.cs
@@ -1,0 +1,66 @@
+﻿//
+//  20250613142500_AddGraduationProgrammeRole.cs
+//
+//  Copyright (c) Christofel authors. All rights reserved.
+//  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Christofel.Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGraduationProgrammeRole : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GraduationAssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProgrammeRoleAssignment_GraduationAssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment",
+                column: "GraduationAssignmentId");
+
+            // Default to the AssignmentId
+            migrationBuilder.Sql(
+                @"UPDATE `Core_ProgrammeRoleAssignment` SET `GraduationAssignmentId` = `AssignmentId`"
+            );
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProgrammeRoleAssignment_RoleAssignment_GraduationAssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment",
+                column: "GraduationAssignmentId",
+                principalSchema: "Core",
+                principalTable: "RoleAssignment",
+                principalColumn: "RoleAssignmentId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProgrammeRoleAssignment_RoleAssignment_GraduationAssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProgrammeRoleAssignment_GraduationAssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment");
+
+            migrationBuilder.DropColumn(
+                name: "GraduationAssignmentId",
+                schema: "Core",
+                table: "ProgrammeRoleAssignment");
+        }
+    }
+}

--- a/src/Libs/Christofel.CtuAuth/Auth/Steps/ProgrammeRoleStep.cs
+++ b/src/Libs/Christofel.CtuAuth/Auth/Steps/ProgrammeRoleStep.cs
@@ -4,8 +4,10 @@
 //   Copyright (c) Christofel authors. All rights reserved.
 //   Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Christofel.Common.Database.Models;
 using Christofel.CtuAuth.Extensions;
 using Kos.Abstractions;
+using Kos.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Remora.Results;
@@ -39,47 +41,125 @@ namespace Christofel.CtuAuth.Auth.Steps
             _logger = logger;
         }
 
+        private record ProgrammeAssignmentSpec(string programme, bool graduated, bool active);
+
+        private async Task<Dictionary<string, ProgrammeAssignmentSpec>> GetSpecs(Person? kosPerson, CancellationToken ct = default)
+        {
+            var studentRoles = kosPerson?.Roles.Students;
+            var activeStudents = await _kosApi.GetActiveStudentRoles(studentRoles, ct);
+            var graduatedStudents = await _kosApi.GetGraduatedStudentRoles(studentRoles, ct);
+            var assignmentSpecs = new Dictionary<string, ProgrammeAssignmentSpec>();
+
+            // No active nor graduated roles,
+            // fallback to latest study role.
+            if (activeStudents.Count == 0 && graduatedStudents.Count == 0)
+            {
+                var latestStudent = await _kosApi.GetLatestStudentRole(studentRoles, ct);
+                if (latestStudent?.Programme?.Title is not null)
+                {
+                    assignmentSpecs.Add
+                        (
+                            latestStudent.Programme.Title,
+                            new ProgrammeAssignmentSpec(latestStudent.Programme.Title, false, true)
+                        );
+                }
+            }
+
+            void updateAssignmentSpecs(IReadOnlyList<Student> studentRoles, Dictionary<string, ProgrammeAssignmentSpec> assignmentSpecs, Func<ProgrammeAssignmentSpec, ProgrammeAssignmentSpec> action)
+            {
+                foreach (var studentRole in studentRoles)
+                {
+                    var programmeTitle = studentRole.Programme?.Title;
+
+                    if (programmeTitle is null)
+                    {
+                        continue;
+                    }
+
+                    var assignmentSpec = assignmentSpecs.ContainsKey(programmeTitle)
+                        ? assignmentSpecs[programmeTitle]
+                        : new ProgrammeAssignmentSpec(programmeTitle, false, false);
+
+                    assignmentSpec = action(assignmentSpec);
+
+                    assignmentSpecs[programmeTitle] = assignmentSpec;
+                }
+            }
+
+            updateAssignmentSpecs
+                (
+                    activeStudents,
+                    assignmentSpecs,
+                    assignmentSpec => assignmentSpec with { active = true }
+                );
+            updateAssignmentSpecs
+                (
+                    graduatedStudents,
+                    assignmentSpecs,
+                    assignmentSpec => assignmentSpec with { graduated = true }
+                );
+
+            return assignmentSpecs;
+        }
+
         /// <inheritdoc />
         public async Task<Result> FillDataAsync(IAuthData data, CancellationToken ct = default)
         {
             var kosPerson =
                 await _kosPeopleApi.GetPersonAsync(data.LoadedUser.CtuUsername, ct);
 
-            var student = await _kosApi.GetLatestStudentRole(kosPerson?.Roles.Students, ct: ct);
+            var assignmentSpecs = await GetSpecs(kosPerson, ct);
 
-            if (student is null)
+            // No role assignments
+            if (assignmentSpecs.Count == 0)
             {
                 return Result.FromSuccess();
             }
 
-            var programmeTitle = student.Programme?.Title;
-
-            if (programmeTitle is null)
+            // NOTE: query is generated for each programme. This could possibly be avoided,
+            // but generally it is expected one programmeTitle per person will be available,
+            // and even if there are multiple, there aren't many users authenticating,
+            // so it should be fine.
+            foreach (var (programmeTitle, assignmentSpec) in assignmentSpecs)
             {
-                return Result.FromSuccess();
+                var graduationRole = !assignmentSpec.active && assignmentSpec.graduated;
+
+                var query = data.DbContext.ProgrammeRoleAssignments
+                    .AsNoTracking()
+                    .Where(x => x.Programme == programmeTitle);
+
+                IQueryable<RoleAssignment?> finalQuery;
+                if (graduationRole)
+                {
+                    finalQuery = query
+                        .Include(x => x.GraduationAssignment)
+                        .Select(x => x.GraduationAssignment);
+                }
+                else
+                {
+                    finalQuery = query
+                        .Include(x => x.Assignment)
+                        .Select(x => x.Assignment);
+                }
+
+                var assignments = await finalQuery
+                    .ToListAsync(ct);
+
+                if (assignments.Count == 0)
+                {
+                    _logger.LogWarning
+                        (
+                            "Could not find mapping for programme {programmeTitle} for user {GuildUser}",
+                            programmeTitle,
+                            data.GuildUser
+                        );
+                }
+
+                var roles = assignments
+                    .Where(x => x is not null)
+                    .Select(x => new CtuAuthRole { RoleId = x!.RoleId, Type = x.RoleType });
+                data.Roles.AddRange(roles);
             }
-
-            var assignments = await data.DbContext.ProgrammeRoleAssignments
-                .AsNoTracking()
-                .Where(x => x.Programme == programmeTitle)
-                .Include(x => x.Assignment)
-                .Select(x => x.Assignment)
-                .ToListAsync(ct);
-
-            if (assignments.Count == 0)
-            {
-                _logger.LogWarning
-                    (
-                        "Could not find mapping for programme {programmeTitle} for user {GuildUser}",
-                        programmeTitle,
-                        data.GuildUser
-                    );
-            }
-
-            var roles = assignments
-                .Where(x => x is not null)
-                .Select(x => new CtuAuthRole { RoleId = x!.RoleId, Type = x.RoleType });
-            data.Roles.AddRange(roles);
 
             return Result.FromSuccess();
         }

--- a/src/Libs/Christofel.CtuAuth/Auth/Steps/SpecificRolesStep.cs
+++ b/src/Libs/Christofel.CtuAuth/Auth/Steps/SpecificRolesStep.cs
@@ -56,10 +56,10 @@ namespace Christofel.CtuAuth.Auth.Steps
                 assignRoleNames.Add("Teacher");
             }
 
-            var currentStudiesRole =
+            var currentStudiesRoles =
                 await ObtainCurrentStudies(data.LoadedUser.CtuUsername, ct);
 
-            if (currentStudiesRole is not null)
+            foreach (var currentStudiesRole in currentStudiesRoles)
             {
                 assignRoleNames.Add(currentStudiesRole);
             }
@@ -97,45 +97,55 @@ namespace Christofel.CtuAuth.Auth.Steps
             return Result.FromSuccess();
         }
 
-        private async Task<string?> ObtainCurrentStudies
+        // Obtains ProgrammeType of all active student roles.
+        private async Task<IReadOnlyList<string>> ObtainCurrentStudies
         (
             string username,
             CancellationToken token = default
         )
         {
             var person = await _kosPeopleApi.GetPersonAsync(username, token);
-            var student = await _kosApi.GetLatestStudentRole(person?.Roles.Students, ct: token);
+            var studentRoles = await _kosApi
+                .GetActiveStudentRoles(person?.Roles.Students, ct: token);
 
-            // Not a student at all, or anymore. Treat interrupted as still studying
-            if (student is null || student.StudyState == StudyState.Closed)
+            var programTypes = new List<string>();
+            foreach (var student in studentRoles)
             {
-                return null;
-            }
-
-            try
-            {
-                var programme = await _kosApi.LoadEntryAsync(student.Programme, token: token);
-
-                if (programme is null)
+                try
                 {
-                    return null;
+                    var programme = await _kosApi
+                        .LoadEntryAsync(student.Programme, token: token);
+
+                    if (programme is null)
+                    {
+                        continue;
+                    }
+
+                    var programType = programme.Content.ProgrammeType switch
+                    {
+                        ProgrammeType.Bachelor => "BachelorProgramme",
+                        ProgrammeType.Master => "MasterProgramme",
+                        ProgrammeType.MasterLegacy => "MasterProgramme",
+                        ProgrammeType.Doctoral => "DoctoralProgramme",
+                        _ => null,
+                    };
+
+                    if (programType is not null)
+                    {
+                        programTypes.Add(programType);
+                    }
                 }
-
-                return programme.Content.ProgrammeType switch
+                catch (Exception e)
                 {
-                    ProgrammeType.Bachelor => "BachelorProgramme",
-                    ProgrammeType.Master => "MasterProgramme",
-                    ProgrammeType.MasterLegacy => "MasterProgramme",
-                    ProgrammeType.Doctoral => "DoctoralProgramme",
-                    _ => null,
-                };
-            }
-            catch (Exception e)
-            {
-                _logger.LogWarning(e, "There was an exception thrown whilst obtaining a programme.");
+                    _logger.LogWarning
+                        (
+                            e,
+                            "There was an exception thrown whilst obtaining a programme."
+                        );
+                }
             }
 
-            return null;
+            return programTypes.AsReadOnly();
         }
 
         private async Task<bool> IsTeacherAsync(string username, CancellationToken token = default)

--- a/src/Libs/Christofel.CtuAuth/Extensions/KosStudentsApiExtensions.cs
+++ b/src/Libs/Christofel.CtuAuth/Extensions/KosStudentsApiExtensions.cs
@@ -50,6 +50,82 @@ public static class KosStudentsApiExtensions
     )
         => api.GetExtremeStudentRole(studentRoles, false, groupBy, ct);
 
+    /// <summary>
+    /// Obtains Student roles from the given list that are still
+    /// active (not terminated). The StudyState is checked for Closed,
+    /// and the EndDate is checked. The EndDate has to be null or in the future,
+    /// the studystate cannot be closed.
+    /// </summary>
+    /// <param name="api">The kos api.</param>
+    /// <param name="studentRoles">The student roles to look through.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task<IReadOnlyList<Student>> GetActiveStudentRoles
+        (
+            this IKosAtomApi api,
+            List<AtomLoadableEntity<Student>>? studentRoles,
+            CancellationToken ct = default
+        )
+        => await api.FilterStudentRoles
+        (
+            studentRoles,
+            (student) => student.StudyState != StudyState.Closed && (student.EndDate is null || student.EndDate > DateTime.Now),
+            ct
+        );
+
+    /// <summary>
+    /// Obtains Student roles from the given list that are are past graduation.
+    /// Meaning the StudyTerminationReason is Graduation.
+    /// </summary>
+    /// <param name="api">The kos api.</param>
+    /// <param name="studentRoles">The student roles to look through.</param>
+    /// <param name="ct">The cancellation token for the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task<IReadOnlyList<Student>> GetGraduatedStudentRoles
+        (
+            this IKosAtomApi api,
+            List<AtomLoadableEntity<Student>>? studentRoles,
+            CancellationToken ct = default
+        )
+        => await api.FilterStudentRoles
+        (
+            studentRoles,
+            (student) => student.StudyTerminationReason == StudyTermination.Graduation,
+            ct
+        );
+
+    private static async Task<IReadOnlyList<Student>> FilterStudentRoles
+        (
+            this IKosAtomApi api,
+            List<AtomLoadableEntity<Student>>? studentRoles,
+            Func<Student, bool> filter,
+            CancellationToken ct = default
+        )
+    {
+        if (studentRoles is null)
+        {
+            return Array.Empty<Student>();
+        }
+
+        var activeStudents = new List<Student>();
+        foreach (var studentRole in studentRoles)
+        {
+            var currentStudent = await api.LoadEntityContentAsync(studentRole, token: ct);
+
+            if (currentStudent is null)
+            {
+                continue;
+            }
+
+            if (filter(currentStudent))
+            {
+                activeStudents.Add(currentStudent);
+            }
+        }
+
+        return activeStudents.AsReadOnly();
+    }
+
     private static async Task<Student?> GetExtremeStudentRole
     (
         this IKosAtomApi api,


### PR DESCRIPTION
The current scenario is that last student role is always retrieved from kos api. This however is not covering all cases well.

First, there are cases that are undisputedly wrong, consider a student starting their studies on programme A, after year they also start programme B, then end B, but are still studying A. After they started studying B, B role will be assigned to them, only, that is even after they end the studies on B.

The new agreed behavior is as so:
There will be distinct active and graduated roles.

All active study roles are retrieved (active meaning the study is still ongoing or interrupted) and the user is assigned the active roles according to programmes of those roles.
All gratudated study roles are retrieved (gratuated meaning the termination state is Graduation) and the user is assigned the graduated roles according to programmes of these roles insofar they don't have active student role with the same programme.

If there are no active nor graduated study roles, only the latest study role is used instead. Note that this case is almost impossible.

# Implications
Going to the previously outlined case, the student will get A assigned throughout their whole studies, and B only when they are on B. After they quit B, they will get only A assigned.

For more common cases, the students that study a different programme on bachelor's and master's will get both of those programmes assigned.